### PR TITLE
fix(safari/typing-game): `passage` garbled text

### DIFF
--- a/pages/projects/typing-game.vue
+++ b/pages/projects/typing-game.vue
@@ -287,6 +287,7 @@
     <div
       v-if="data?.mappedPassage?.length"
       v-show="!isPrompt"
+      :key="data.id"
       ref="passageContainer"
       class="container mt-2 focus:outline-none"
       tabindex="0"


### PR DESCRIPTION
fixed `passage` rendering on Safari browser.

</br>
<img width="1200" height="810" alt="Screenshot 2025-10-02 at 10 22 11 PM" src="https://github.com/user-attachments/assets/31e639c4-f2ae-4286-a50f-3f2a48b3487d" />
