### PR TITLE
chore(global): use explicit static icons

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -41,14 +41,12 @@ export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
   icon: {
     clientBundle: {
-      icons: [
-        'material-symbols:app-badging-outline',
-        'material-symbols:chart-data-outline',
-        'material-symbols:moon-stars-outline-rounded',
-        'material-symbols:arrow-outward-rounded',
-        'material-symbols:sunny-outline-rounded',
-        'material-symbols:link-rounded',
-        'material-symbols:keyboard-external-input-outline',
+      scan: true, // pre-render explicitly used icons from installed @iconify-json/* packages
+      icons: [ // icons rendered dynamically
+        'simple-icons:github',
+        'simple-icons:linkedin',
+        'simple-icons:twitter',
+        'simple-icons:instagram',
       ],
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "nuxt-app",
       "hasInstallScript": true,
       "dependencies": {
+        "@iconify-json/simple-icons": "^1.2.54",
         "@nuxt/eslint": "^1.3.0",
         "@nuxt/image": "^1.10.0",
         "@nuxt/ui": "^3.2.0",
@@ -1558,6 +1559,15 @@
       "integrity": "sha512-3dA1jxkCd8LqEaAWjwQ5tob4pJNKE59Bz604AL1GP3Kyv//pR3un3cIyAUWOFQS1lz0vKKkn0BKOCmcUDi1G8A==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.54",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.54.tgz",
+      "integrity": "sha512-OQQYl8yC5j3QklZOYnK31QYe5h47IhyCoxSLd53f0e0nA4dgi8VOZS30SgSAbsecQ+S0xlGJMjXIHTIqZ+ML3w==",
+      "license": "CC0-1.0",
       "dependencies": {
         "@iconify/types": "*"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "@iconify-json/simple-icons": "^1.2.54",
     "@nuxt/eslint": "^1.3.0",
     "@nuxt/image": "^1.10.0",
     "@nuxt/ui": "^3.2.0",

--- a/pages/projects/currency-converter.vue
+++ b/pages/projects/currency-converter.vue
@@ -2,6 +2,7 @@
   <div>
     <UBreadcrumb
       class="mt-8"
+      separator-icon="material-symbols:chevron-right"
       :items="crumbItems"
       :ui="{ link: 'text-lg' }" />
 
@@ -81,8 +82,13 @@
               variant="subtle"
               color="neutral"
               icon="material-symbols:flag-outline-rounded"
+              selected-icon="material-symbols:check"
+              trailing-icon="material-symbols:keyboard-arrow-down"
               :placeholder="$t('From')"
               :items="currenciesList.filter(item => item.code !== state.target?.code)"
+              :ui="{
+                trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200',
+              }"
               @update:model-value="onChangeSource"
               @update:open="onOpenSelect">
               <template #empty>
@@ -123,8 +129,13 @@
               variant="subtle"
               color="neutral"
               icon="material-symbols:flag-outline-rounded"
+              selected-icon="material-symbols:check"
+              trailing-icon="material-symbols:keyboard-arrow-down"
               :placeholder="$t('To')"
               :items="currenciesList.filter(item => item.code !== state.source?.code)"
+              :ui="{
+                trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200',
+              }"
               @update:open="onOpenSelect">
               <template #empty>
                 {{ statusCurrencies === 'pending' ? $t('Loading') : $t('NoData') }}

--- a/pages/projects/treasury-yield-visualiser.vue
+++ b/pages/projects/treasury-yield-visualiser.vue
@@ -11,6 +11,7 @@
     <template v-if="chart">
       <UBreadcrumb
         class="mt-8"
+        separator-icon="material-symbols:chevron-right"
         :items="crumbItems"
         :ui="{ link: 'text-lg' }" />
 
@@ -32,8 +33,13 @@
               v-model="selectedFromYear"
               size="xs"
               class="w-20"
+              trailing-icon="material-symbols:keyboard-arrow-down"
+              selected-icon="material-symbols:check"
               :disabled="statusChart === 'pending'"
               :items="yearsList"
+              :ui="{
+                trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200',
+              }"
               @change="onChange('from')" />
           </UFormField>
           <UFormField :label="$t('To')">
@@ -41,8 +47,13 @@
               v-model="selectedToYear"
               size="xs"
               class="w-20"
+              trailing-icon="material-symbols:keyboard-arrow-down"
+              selected-icon="material-symbols:check"
               :disabled="statusChart === 'pending'"
               :items="yearsList"
+              :ui="{
+                trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200',
+              }"
               @change="onChange('to')" />
           </UFormField>
         </div>
@@ -76,6 +87,7 @@
             v-model="termCheckboxes"
             required
             orientation="horizontal"
+            icon="material-symbols:check-small"
             :disabled="statusChart === 'pending'"
             :items="termItems"
             :ui="{ indicator: 'bg-transparent text-default' }">
@@ -94,6 +106,7 @@
             v-model="spreadCheckboxes"
             required
             orientation="horizontal"
+            icon="material-symbols:check-small"
             :disabled="statusChart === 'pending'"
             :items="spreadItems"
             :ui="{ indicator: 'bg-transparent text-default', fieldset: 'max-w-72' }">

--- a/pages/projects/typing-game.vue
+++ b/pages/projects/typing-game.vue
@@ -2,6 +2,7 @@
   <div class="w-full min-h-[inherit]">
     <UBreadcrumb
       class="mt-8"
+      separator-icon="material-symbols:chevron-right"
       :items="crumbItems"
       :ui="{ link: 'text-lg' }" />
 


### PR DESCRIPTION
- to replace default NuxtUI `lucide` icons
- to have all icons server rendered