### PR TITLE
fix: build time prerender logic

### DIFF
--- a/components/Projects/currency-converter.vue
+++ b/components/Projects/currency-converter.vue
@@ -22,23 +22,12 @@
       class="mt-8"
       :schema="CurrencyFormSchema"
       :state="state">
-      <UCard
-        :ui="{ body: 'space-y-8' }">
-        <div class="flex justify-between">
+      <UCard :ui="{ body: 'space-y-8' }">
+        <div>
           <UBadge
-            class="self-start"
             color="warning"
             variant="soft"
             :label="$t('Simulation')" />
-          <UButton
-            size="sm"
-            color="neutral"
-            variant="link"
-            icon="material-symbols:format-list-bulleted"
-            :label="$t('GoToTarget', { target: $t('List') })"
-            :aria-label="$t('GoToTarget', { target: $t('List') })"
-            :disabled="statusCurrencies === 'pending' || statusRates === 'pending'"
-            :to="localePath('/projects')" />
         </div>
 
         <UFormField

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -50,7 +50,6 @@
   "NextItem": "Next {item}",
   "SelfDevelopedApplications": "Self developed application | Self developed applications",
   "GoBack": "Go back",
-  "GoToTarget": "Go to {target}",
   "Mode": "Mode",
   "Standard": "Standard",
   "Spread": "Spread",

--- a/i18n/locales/th.json
+++ b/i18n/locales/th.json
@@ -50,7 +50,6 @@
   "NextItem": "{item} ถัดไป",
   "SelfDevelopedApplications": "แอปพลิเคชันที่พัฒนาด้วยตนเอง",
   "GoBack": "ย้อนกลับ",
-  "GoToTarget": "ไปที่ {target}",
   "Mode": "โหมด",
   "Standard": "มาตรฐาน",
   "Spread": "ส่วนต่าง",

--- a/i18n/locales/tr.json
+++ b/i18n/locales/tr.json
@@ -50,7 +50,6 @@
   "NextItem": "Sonraki {item}",
   "SelfDevelopedApplications": "Kendi geliştirdiğiniz uygulamalar",
   "GoBack": "Geri dön",
-  "GoToTarget": "{target} adresine git",
   "Mode": "Mod",
   "Standard": "Standart",
   "Spread": "Fark",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -50,7 +50,6 @@
   "NextItem": "下一个{item}",
   "SelfDevelopedApplications": "自研应用程序",
   "GoBack": "返回",
-  "GoToTarget": "前往 {target}",
   "Mode": "模式",
   "Standard": "标准",
   "Spread": "差值",


### PR DESCRIPTION
Description:

- prerender based on `published` status of project item
- show `UAlert` if content not available for the selected locale
- throw error to bring up `error.vue` if content is not available for all locales

remark: each cms entry has its own `published` / `draft` state.