### PR TITLE
fix(i18n): prevent premature locale update before page navigation

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -42,7 +42,12 @@
       </h2>
 
       <NuxtLayout>
-        <NuxtPage />
+        <NuxtPage
+          :transition="{
+            name: 'page',
+            mode: 'out-in',
+            onBeforeEnter,
+          }" />
       </NuxtLayout>
     </main>
 
@@ -95,7 +100,12 @@ const route = useRoute();
 const nuxtApp = useNuxtApp();
 const localePath = useLocalePath();
 
-const { t: $t, locale, locales } = useI18n();
+const {
+  t: $t,
+  locale,
+  locales,
+  finalizePendingLocaleChange,
+} = useI18n();
 
 const lang = computed(() => locale.value);
 
@@ -230,6 +240,10 @@ const menuItems = computed<NavigationMenuItem[]>(() => [
     to: localePath('/tech-stacks'),
   },
 ]);
+
+const onBeforeEnter = async () => {
+  await finalizePendingLocaleChange();
+};
 </script>
 
 <style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -27,10 +27,7 @@ const fetchPublishedProjectSlugs = async () => {
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   ssr: true,
-  app: {
-    pageTransition: { name: 'page', mode: 'out-in' },
-    // layoutTransition: { name: 'layout', mode: 'out-in' }, // un-comment when additional layouts are being used
-  },
+
   runtimeConfig: {
     strapiReadOnlyToken: process.env.NUXT_STRAPI_READ_ONLY_TOKEN,
     strapiApiBase: process.env.NUXT_STRAPI_API_BASE,
@@ -89,6 +86,7 @@ export default defineNuxtConfig({
     ],
     lazy: true,
     strategy: 'prefix_except_default',
+    skipSettingLocaleOnNavigate: true,
   },
   hooks: {
     // https://nuxt.com/docs/3.x/getting-started/prerendering#prerenderroutes-nuxt-hook


### PR DESCRIPTION
resolves #30 

[https://nuxt.com/docs/3.x/migration/component-options#scrolltotop](https://nuxt.com/docs/3.x/migration/component-options#scrolltotop)
[https://router.vuejs.org/api/interfaces/RouterOptions.html#scrollBehavior-](https://router.vuejs.org/api/interfaces/RouterOptions.html#scrollBehavior-)
[https://v9.i18n.nuxtjs.org/docs/guide/lang-switcher/#wait-for-page-transition](https://v9.i18n.nuxtjs.org/docs/guide/lang-switcher/#wait-for-page-transition)